### PR TITLE
bugfix/ATC-32 - adds no cache flag to npm start cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "report": "nyc report --reporter=cobertura  --reporter=lcov",
     "coverage": "npm run test && npm run report",
     "lint": "eslint src/**; exit 0",
-    "start": "gulp dist && http-server -p 3003"
+    "start": "gulp dist && http-server -p 3003 -c -1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
completes #32
