### PR TITLE
bugfix/ATC-65

### DIFF
--- a/src/assets/scripts/airline/AirlineModel.js
+++ b/src/assets/scripts/airline/AirlineModel.js
@@ -51,11 +51,16 @@ export default class AirlineModel {
     /**
      * Initialize object from data
      *
+     * This method will be called twice at minimum; once on instantiation and again once
+     * `onLoadSuccess`. Most of the properties below will only be available `onLoadSuccess`
+     *
      * @for AirlineModel
      * @method parse
      * @param data {object}
      */
     parse(data) {
+        this.icao = _get(data, 'icao', this.icao);
+
         if (data.callsign) {
             this.callsign = data.callsign.name;
 


### PR DESCRIPTION
fixes #65 (ref original issue https://github.com/zlsa/atc/issues/711)

Adds _get in AirlineModel.parse() to re-set the icao property. Icao was only being set in the constructor and was missing the second pass that happens post-data load.