### PR TITLE
bugfix/ATC-145

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.2.0 (December 20, 2016)
+---
+### Major
+
+
+### Minor
+
+
+### Bugfixes
+- Moves `_comment` blocks in airport json file to be within object the are describing [#145](https://github.com/n8rzz/atc/issues/145)
+
+
 ## 3.1.0 (November 20, 2016)
 ---
 ### Major

--- a/assets/airports/eham.json
+++ b/assets/airports/eham.json
@@ -1005,8 +1005,8 @@
         ["PESER", "STD", "RIVER"]
       ]
     },
-    "_comment": "ARTIP1X is a day transition for 36R",
     "ARTIP1X": {
+      "_comment": "ARTIP1X is a day transition for 36R",
       "icao": "ARTIP1X",
       "name": "Artip One Xray",
       "entryPoint": {
@@ -1017,8 +1017,8 @@
         ["ARTIP", "PAM", "EH611", "EH612", "SOKSI", "EH613", "EH614", "EH609"]
       ]
     },
-    "_comment_": "Beyond this point are the instrument approach procedures/transitions for night usage",
     "ARTIP2A": {
+      "_comment_": "Beyond this point are the instrument approach procedures/transitions for night usage",
       "icao": "ARTIP2A",
       "name": "Artip Two Alfa",
       "entryPoint": {


### PR DESCRIPTION
fixes #145 

Moves _comment blocks to be within object they are describing in airport json.