### PR TITLE
bugfix/ATC-185

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 ### Bugfixes
 - Moves `_comment` blocks in airport json file to be within object the are describing [#145](https://github.com/n8rzz/atc/issues/145)
 - Streamlines flight number generation and adds new method to add new callsigns to the existing list [#151](https://github.com/n8rzz/atc/issues/151)
+- Adds `_isNumber` check instead of `!magneticNorth` inside `PositionModel.calculatePosition()` and the `AirspaceModel` constructor. [#182](https://github.com/n8rzz/atc/issues/182)
+    - Originally reported under [#754](https://github.com/zlsa/atc/issues/754)
 
 
 

--- a/src/assets/scripts/airport/AirspaceModel.js
+++ b/src/assets/scripts/airport/AirspaceModel.js
@@ -1,4 +1,5 @@
 import _isEqual from 'lodash/isEqual';
+import _isNumber from 'lodash/isNumber';
 import _map from 'lodash/map';
 import BaseModel from '../base/BaseModel';
 import PositionModel from '../base/PositionModel';
@@ -30,7 +31,7 @@ export default class AirspaceModel extends BaseModel {
     constructor(airspace, airportPosition, magneticNorth) {
         super();
 
-        if (!airspace || !airportPosition || !magneticNorth) {
+        if (!airspace || !airportPosition || !_isNumber(magneticNorth)) {
             // eslint-disable-next-line max-len
             throw new TypeError('Invalid parameter, expected airspace, airportPosition and magneticNorth to be defined');
         }

--- a/src/assets/scripts/base/PositionModel.js
+++ b/src/assets/scripts/base/PositionModel.js
@@ -1,3 +1,4 @@
+import _isNumber from 'lodash/isNumber';
 import _uniqueId from 'lodash/uniqueId';
 import {
     calculateDistanceToPointForX,
@@ -245,7 +246,7 @@ export default class PositionModel {
  * @static
  */
 PositionModel.calculatePosition = (coordinates, referencePostion, magneticNorth) => {
-    if (!coordinates || !referencePostion || !magneticNorth) {
+    if (!coordinates || !referencePostion || !_isNumber(magneticNorth)) {
         throw new TypeError('Invalid parameter. PositionModel.getPosition() requires coordinates, referencePostion ' +
             'and magneticNorth as parameters');
     }

--- a/test/airport/AirspaceModel.spec.js
+++ b/test/airport/AirspaceModel.spec.js
@@ -17,6 +17,10 @@ ava('throws if called with invalid parameters', t => {
     t.throws(() => new AirspaceModel(AIRSPACE_MOCK, airportPositionFixtureKSFO));
 });
 
+ava('does not throw when instantiated with a 0 magneticNorth', t => {
+    t.notThrows(() => new AirspaceModel(AIRSPACE_MOCK, airportPositionFixtureKSFO, 0));
+})
+
 ava('accepts an airspace object that is used to set the class properties', t => {
     const model = new AirspaceModel(AIRSPACE_MOCK, airportPositionFixtureKSFO, magneticNorth);
 

--- a/test/base/PositionModel.spec.js
+++ b/test/base/PositionModel.spec.js
@@ -38,3 +38,9 @@ ava('.getPostiion() returns an array with a calculated x, y value that is the sa
 
     t.true(_isEqual(result, expectedResult.position));
 });
+
+// user bug test cases
+ava('.calculatePosition() does not throw when it receives 0 for magnetic_north', t => {
+    t.notThrows(() => new PositionModel(LAT_LONG_MOCK, airportPositionFixtureKLAS, 0));
+    t.notThrows(() => PositionModel.calculatePosition(LAT_LONG_MOCK, airportPositionFixtureKLAS, 0));
+});


### PR DESCRIPTION
fixes #185 (https://github.com/zlsa/atc/issues/754)

Adds `_isNumber()` check instead of `!magneticNorth` inside `PositionModel.calculatePosition()` and the `AirspaceModel` constructor.