### PR TITLE
bugfix/ATC-237

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@
 
 
 ### Bugfixes
-- Resets current indicies when issuing a new star to an arriving aircraft [#237](https://github.com/n8rzz/atc/issues/237)
-    - Originally reported under [zlsa#768](https://github.com/zlsa/atc/issues/768)
+- Resets current indicies when issuing a new star to an arriving aircraft [#104](https://github.com/n8rzz/atc/issues/104) & [#237](https://github.com/n8rzz/atc/issues/237)
+    - Originally reported under [zlsa#730](https://github.com/zlsa/atc/issues/730) & [zlsa#768](https://github.com/zlsa/atc/issues/768)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 
 ### Bugfixes
+- Resets current indicies when issuing a new star to an arriving aircraft [#237](https://github.com/n8rzz/atc/issues/237)
+    - Originally reported under [zlsa#768](https://github.com/zlsa/atc/issues/768)
+
+
 
 
 

--- a/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
@@ -2167,7 +2167,7 @@ export default class Aircraft {
             this.target.altitude = this.fms.altitudeForCurrentWaypoint();
             this.target.expedite = this.fms.currentWaypoint.expedite;
             this.target.altitude = Math.max(1000, this.target.altitude);
-            this.target.speed = this.fms.currentWaypoint.speed;
+            this.target.speed = _get(this, 'fms.currentWaypoint.speed', this.speed);
             this.target.speed = clamp(this.model.speed.min, this.target.speed, this.model.speed.max);
         }
 

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/AircraftFlightManagementSystem.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/AircraftFlightManagementSystem.js
@@ -547,8 +547,13 @@ export default class AircraftFlightManagementSystem {
             }
         }
 
+        // this may not be the correct spot for this
+        this.current = [0, 0];
         // Add the new STAR Leg
-        this.appendLeg({ type: FP_LEG_TYPE.STAR, route: route });
+        this.appendLeg({
+            route,
+            type: FP_LEG_TYPE.STAR
+        });
     }
 
     // TODO: move this logic to the `RouteModel`
@@ -597,7 +602,7 @@ export default class AircraftFlightManagementSystem {
                 // TODO: this should be abstracted to another class method.
                 const pieces = data[i].split('.');
                 // FIXME: what does 'a' mean? better naming
-                a = [pieces[0] + '.' + pieces[1] + '.' + pieces[2]];
+                a = [`${pieces[0]}.${pieces[1]}.${pieces[2]}`];
 
                 // chop up the multilink
                 for (let j = 3; j < data[i].split('.').length; j + 2) {


### PR DESCRIPTION
fixes #237, fixes n8rzz/atc#104 

Adds reset for current indicies within followSTAR method and a get fallback for currentWaypoint speed

_note: in order for this to fully resolve https://github.com/zlsa/atc/issues/768, the `LOWW` airport file will need to be updated to include the correct entry points and at least one exit point for stars._