### PR TITLE
bugfix/ATC-266

### DIFF
--- a/src/assets/scripts/client/aircraft/AircraftCommander.js
+++ b/src/assets/scripts/client/aircraft/AircraftCommander.js
@@ -161,7 +161,7 @@ export default class AircraftCommander {
 
             this._uiController.ui_log(`${aircraft.getCallsign()}, ${r_log} ${response_end}`);
             speech_say([
-                { type: 'callsign', content: this },
+                { type: 'callsign', content: aircraft },
                 { type: 'text', content: `${r_say} ${response_end}` }
             ]);
         }

--- a/src/assets/scripts/client/aircraft/AircraftController.js
+++ b/src/assets/scripts/client/aircraft/AircraftController.js
@@ -501,6 +501,7 @@ export default class AircraftController {
             callsign: flightNumber,
             category: spawnPatternModel.category,
             airline: airlineModel.icao,
+            airlineCallsign: airlineModel.callsign,
             altitude: spawnPatternModel.altitude,
             speed: spawnPatternModel.speed,
             heading: spawnPatternModel.heading,

--- a/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftInstanceModel.js
@@ -72,7 +72,9 @@ export default class Aircraft {
         this.eid          = prop.aircraft.list.length;  // entity ID
         this.position     = [0, 0];     // Aircraft Position, in km, relative to airport position
         this.model        = null;       // Aircraft type
-        this.airline      = '';         // Airline Identifier (eg. 'AAL')
+        this.airlineId      = '';         // Airline Identifier (eg. 'AAL')
+        this.airlineCallsign = '';
+        // FIXME: change this to`flightNumber`
         this.callsign     = '';         // Flight Number ONLY (eg. '551')
         this.heading      = 0;          // Magnetic Heading
         this.altitude     = 0;          // Altitude, ft MSL
@@ -220,7 +222,8 @@ export default class Aircraft {
     parse(data) {
         this.position = _get(data, 'position', this.position);
         this.model = _get(data, 'model', this.model);
-        this.airline = _get(data, 'airline', this.airline);
+        this.airlineId = _get(data, 'airline', this.airlineId);
+        this.airlineCallsign = _get(data, 'airlineCallsign', this.airlineCallsign);
         this.callsign = _get(data, 'callsign', this.callsign);
         this.category = _get(data, 'category', this.category);
         this.heading = _get(data, 'heading', this.heading);
@@ -472,7 +475,6 @@ export default class Aircraft {
         return _isEqual(callsignToMatch.toUpperCase(), this.getCallsign());
     }
 
-    // TODO: This model should store this information as instance properties and not calculate it all the time
     /**
      * @for AircraftInstanceModel
      * @method getCallsign
@@ -481,7 +483,7 @@ export default class Aircraft {
     getCallsign() {
         // TODO: this should be an instance property. however, it seems callsign is used in places where it should be
         // flightnumber and visa versa. this needs to be ironed out first before making a class property.
-        return `${this.airline.toUpperCase()}${this.callsign.toUpperCase()}`;
+        return `${this.airlineId.toUpperCase()}${this.callsign.toUpperCase()}`;
     }
 
     /**
@@ -500,18 +502,18 @@ export default class Aircraft {
             heavy = ' super';
         }
 
-        let callsign = this.callsign;
+        let flightNumber = this.callsign;
         if (condensed) {
             const length = 2;
-            callsign = callsign.substr(callsign.length - length);
+            flightNumber = flightNumber.substr(flightNumber.length - length);
         }
 
-        let cs = this.getCallsign();
+        let cs = this.airlineCallsign;
 
         if (cs === 'November') {
-            cs += ` ${radio_spellOut(callsign)} ${heavy}`;
+            cs += ` ${radio_spellOut(flightNumber)} ${heavy}`;
         } else {
-            cs += ` ${groupNumbers(callsign, this.airline)} ${heavy}`;
+            cs += ` ${groupNumbers(flightNumber, this.airlineId)} ${heavy}`;
         }
 
         return cs;

--- a/test/aircraft/_mocks/aircraftMocks.js
+++ b/test/aircraft/_mocks/aircraftMocks.js
@@ -82,6 +82,7 @@ export const AIRCRAFT_INITIALIZATION_PROPS_MOCK = {
     destination: 'KLAS',
     fleet: '',
     airline: 'aal',
+    airlineCallsign: 'speedbird',
     altitude: 28000,
     speed: 320,
     category: 'arrival',


### PR DESCRIPTION
fixes #266 

updates this reference to use aircraft var in AircraftCommander

* adds airlineCallsign prop
* renames AircraftInstanceModel.airline to .ailineId